### PR TITLE
Fixed missing event-kit dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "theorist": "~1.0.2",
     "react-tools": "0.12.2",
     "ect": "~0.5.9",
-    "chokidar": ">=0.2.6"
+    "chokidar": ">=0.2.6",
+    "event-kit": "~1.0.2"
   }
 }


### PR DESCRIPTION
The package activation fails (#9) because of missing [`event-kit`](https://npmjs.org/package/event-kit) module