### PR TITLE
Removes dependency on deprecated TextEditor constructor in 1.8.0-beta3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 .DS_Store
-
+/node_modules/*
+!/node_modules/.bin
+/node_modules/.bin/*
+!/node_modules/htmlmd*
+!/node_modules/htmltojsx*
 npm-debug.log
 spec/**/*.*

--- a/lib/build-text-editor.coffee
+++ b/lib/build-text-editor.coffee
@@ -1,9 +1,7 @@
 TextEditor = null
 module.exports = (params) ->
   if atom.workspace.buildTextEditor?
-    console.log 'building text editor'
     atom.workspace.buildTextEditor(params)
   else
-    console.log 'newing up text editor'
     TextEditor ?= require("atom").TextEditor
     new TextEditor(params)

--- a/lib/build-text-editor.coffee
+++ b/lib/build-text-editor.coffee
@@ -1,0 +1,9 @@
+TextEditor = null
+module.exports = (params) ->
+  if atom.workspace.buildTextEditor?
+    console.log 'building text editor'
+    atom.workspace.buildTextEditor(params)
+  else
+    console.log 'newing up text editor'
+    TextEditor ?= require("atom").TextEditor
+    new TextEditor(params)

--- a/lib/panel-view.coffee
+++ b/lib/panel-view.coffee
@@ -35,29 +35,29 @@ class PanelView extends ScrollView
     @editor
 
   dragStart: (evt,ele)->
+    view = @view()
+    editorHeight = view.find('atom-text-editor').height()
+    top = view.parent().position().top
+    ht = view.height()
+    width = view.width()
+    view.css position :'fixed'
+    view.css top: evt.pageY
+    view.css width: width
+    view.css 'max-height', ''
+    view.css height: ht
+    $(document).mousemove (evt,ele)=>
       view = @view()
-      editorHeight = view.find('atom-text-editor').height()
-      top = view.parent().position().top
-      ht = view.height()
-      width = view.width()
-      view.css position :'fixed'
       view.css top: evt.pageY
-      view.css width: width
-      view.css 'max-height', ''
-      view.css height: ht
-      $(document).mousemove (evt,ele)=>
-        view = @view()
-        view.css top: evt.pageY
-        height = ht +  top - evt.pageY
-        height = height * -1 if height < 0
-        textEditorHeight = editorHeight +  top - evt.pageY
-        textEditorHeight = textEditorHeight * -1 if textEditorHeight < 0
-        view.find('atom-text-editor').css height: textEditorHeight
-        view.css height: height
-      $(document).mouseup (evt,ele)=>
-        view = @view().view()
-        view.css position :'static'
-        $(document).unbind('mousemove')
+      height = ht +  top - evt.pageY
+      height = height * -1 if height < 0
+      textEditorHeight = editorHeight +  top - evt.pageY
+      textEditorHeight = textEditorHeight * -1 if textEditorHeight < 0
+      view.find('atom-text-editor').css height: textEditorHeight
+      view.css height: height
+    $(document).mouseup (evt,ele)=>
+      view = @view().view()
+      view.css position :'static'
+      $(document).unbind('mousemove')
 
   attach: ->
     $(document).keyup (e)=>

--- a/lib/panel-view.coffee
+++ b/lib/panel-view.coffee
@@ -1,10 +1,10 @@
-{TextEditor}  = require 'atom'
+buildTextEditor = require './build-text-editor'
 {$, ScrollView} = require 'atom-space-pen-views'
 
 module.exports =
 class PanelView extends ScrollView
   constructor: (@title,@src,@grammar)->
-    @editor = new TextEditor mini:false
+    @editor = buildTextEditor mini:false
     @attach()
     super
 

--- a/lib/preview-plus.coffee
+++ b/lib/preview-plus.coffee
@@ -16,13 +16,13 @@ module.exports =
     @previewStatus.live.toggleClass 'on'
 
   toggleHTML: ->
-      atom.config.set 'preview-plus.htmlp', !atom.config.get 'preview-plus.htmlp'
-      if editor = atom.workspace.getActiveTextEditor()
-        key = @getGrammar editor
-        if atom.config.get('preview-plus.htmlp')
-          @previewStatus.updateCompileTo('htmlp') if 'htmlp' in @config[key]["enum"]
-        else
-          @previewStatus.updateCompileTo atom.config.get "preview-plus.#{key}"
+    atom.config.set 'preview-plus.htmlp', !atom.config.get 'preview-plus.htmlp'
+    if editor = atom.workspace.getActiveTextEditor()
+      key = @getGrammar editor
+      if atom.config.get('preview-plus.htmlp')
+        @previewStatus.updateCompileTo('htmlp') if 'htmlp' in @config[key]["enum"]
+      else
+        @previewStatus.updateCompileTo atom.config.get "preview-plus.#{key}"
 
   showConfig: ->
     # srcdir = atom.project.get('preview-plus.srcdir')
@@ -93,7 +93,7 @@ module.exports =
     @subscriptions = new CompositeDisposable()
     idx = null
     itemSets = atom.contextMenu.itemSets
-    contextMenu = _.find itemSets, (item,itemIdx)->
+    contextMenu = _.find itemSets, (item,itemIdx) ->
                     idx = itemIdx
                     item.items[0]?.command is 'preview-plus:preview'
 
@@ -179,11 +179,11 @@ module.exports =
         @preview editor,fpath,error,true
 
   getContent: (tag,text)->
-      regex = new RegExp("<pp-#{tag}>([\\s\\S]*?)</pp-#{tag}>")
-      match = text.match(regex)
-      if match? and match[1].trim()
-        data = loophole.allowUnsafeEval ->
-            eval "(#{match[1]})"
+    regex = new RegExp("<pp-#{tag}>([\\s\\S]*?)</pp-#{tag}>")
+    match = text.match(regex)
+    if match? and match[1].trim()
+      data = loophole.allowUnsafeEval ->
+        eval "(#{match[1]})"
 
   preview: (editor,fpath,text,err=false)->
     activePane = atom.workspace.paneForItem(editor)


### PR DESCRIPTION
When `preview-plus` is installed in Atom `1.8.0-beta3` the following warning is logged by Deprecation Cop:

> The `TextEditor` constructor is no longer public: To construct a text editor, use `atom.workspace.buildTextEditor()`. To check if an object is a text editor, use `atom.workspace.isTextEditor(object)`.

I have borrowed the `build-text-editor.coffee` from the Find and Replace package so that we can support legacy implementations if they still exist.
